### PR TITLE
Mismatched lower/upper case

### DIFF
--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -230,8 +230,9 @@ QStringList GameSkyrimSE::CCPlugins() const
   const QString path = gameDirectory().filePath("Skyrim.ccc");
 
   MOBase::forEachLineInFile(path, [&](QString s) {
-    if (!pluginsLookup.contains(s)) {
-      pluginsLookup.insert(s);
+    const auto lc = s.toLower();
+    if (!pluginsLookup.contains(lc)) {
+      pluginsLookup.insert(lc);
       plugins.append(std::move(s));
     }
   });


### PR DESCRIPTION
`forEachLineInFile()` used to return lowercase strings, which would not match the names in `pluginLookup`. This would not typically create problems, unless the `.ccc` file contained duplicates with different cases.

`forEachLineInFile()` has now changed in ModOrganizer2/modorganizer-uibase#72 to return the strings as-is. Both gamebryo and skyrimSE have been updated.