### PR TITLE
Add a setting to allow EnderalSE downloads.

### DIFF
--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -136,7 +136,9 @@ MOBase::VersionInfo GameSkyrimSE::version() const
 
 QList<PluginSetting> GameSkyrimSE::settings() const
 {
-    return QList<PluginSetting>();
+  return {
+    PluginSetting("enderal_downloads", "allow Enderal and Enderal SE downloads", QVariant(false))
+  };
 }
 
 void GameSkyrimSE::initializeProfile(const QDir &path, ProfileSettings settings) const
@@ -207,7 +209,11 @@ QString GameSkyrimSE::gameShortName() const
 
 QStringList GameSkyrimSE::validShortNames() const
 {
-    return { "Skyrim" };
+  QStringList shortNames{ "Skyrim" };
+  if (m_Organizer->pluginSetting(name(), "enderal_downloads").toBool()) {
+    shortNames.append({ "Enderal", "EnderalSE" });
+  }
+  return shortNames;
 }
 
 QString GameSkyrimSE::gameNexusName() const


### PR DESCRIPTION
Add a setting to allow download from Enderal and Enderal SE Nexus.

The Enderal SE plugin will only work with the Steam version, so this allow users to use SSE plugin if they want (there is no equivalent for Enderal LE but this seems to be requested... ).

I think one day we should a more generic way to allow downloads from other Nexus sites to a MO2 instance, but that's not for tomorrow so I think this is good enough for now.