### PR TITLE
Add Skyrim Platform to recognised folder names

### DIFF
--- a/src/skyrimsemoddatachecker.h
+++ b/src/skyrimsemoddatachecker.h
@@ -15,7 +15,7 @@ protected:
       "sound", "strings", "textures", "trees", "video", "facegen", "materials",
       "skse", "distantlod", "asi", "Tools", "MCM", "distantland", "mits",
       "dllplugins", "CalienteTools", "NetScriptFramework", "shadersfx",
-      "Nemesis_Engine"
+      "Nemesis_Engine", "Platform"
     };
     return result;
   }


### PR DESCRIPTION
Currently most mods using Skyrim Platform will include a dummy SKSE folder so that the folder structure is recognised by MO2. This PR just adds SP's "Platform" folder to the list of recognised folder names.

SP's Nexus page is available [here](https://www.nexusmods.com/skyrimspecialedition/mods/54909), and their source code is available [here](https://github.com/skyrim-multiplayer/skymp).