### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -131,7 +131,7 @@ QString GameSkyrimSE::description() const
 
 MOBase::VersionInfo GameSkyrimSE::version() const
 {
-    return VersionInfo(1, 5, 0, VersionInfo::RELEASE_FINAL);
+    return VersionInfo(1, 6, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameSkyrimSE::settings() const

--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -145,7 +145,6 @@ void GameSkyrimSE::initializeProfile(const QDir &path, ProfileSettings settings)
 {
     if (settings.testFlag(IPluginGame::MODS)) {
         copyToProfile(localAppFolder() + "/Skyrim Special Edition", path, "plugins.txt");
-        copyToProfile(localAppFolder() + "/Skyrim Special Edition", path, "loadorder.txt");
     }
 
     if (settings.testFlag(IPluginGame::CONFIGURATION)) {
@@ -282,4 +281,3 @@ MappingType GameSkyrimSE::mappings() const
 
     return result;
 }
-


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.