### PR TITLE
Remove Enderal settings & Add ParticleLights to valid data directories

### DIFF
--- a/src/game_skyrimse_en.ts
+++ b/src/game_skyrimse_en.ts
@@ -4,12 +4,12 @@
 <context>
     <name>GameSkyrimSE</name>
     <message>
-        <location filename="gameskyrimse.cpp" line="212"/>
+        <location filename="gameskyrimse.cpp" line="181"/>
         <source>Skyrim Special Edition Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gameskyrimse.cpp" line="222"/>
+        <location filename="gameskyrimse.cpp" line="191"/>
         <source>Adds support for the game Skyrim Special Edition.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -198,10 +198,7 @@ MOBase::VersionInfo GameSkyrimSE::version() const
 
 QList<PluginSetting> GameSkyrimSE::settings() const
 {
-  return QList<PluginSetting>() << PluginSetting(
-             "enderal_downloads",
-             tr("Allow Enderal and EnderalSE downloads."),
-             true);
+return {}; //Must return something, otherwise linker erros smh
 }
 
 void GameSkyrimSE::initializeProfile(const QDir& path, ProfileSettings settings) const

--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -198,7 +198,10 @@ MOBase::VersionInfo GameSkyrimSE::version() const
 
 QList<PluginSetting> GameSkyrimSE::settings() const
 {
-return {}; //Must return something, otherwise linker erros smh
+  return QList<PluginSetting>() << PluginSetting(
+             "enderal_downloads",
+             tr("Allow Enderal and EnderalSE downloads."),
+             true);
 }
 
 void GameSkyrimSE::initializeProfile(const QDir& path, ProfileSettings settings) const

--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -198,8 +198,7 @@ MOBase::VersionInfo GameSkyrimSE::version() const
 
 QList<PluginSetting> GameSkyrimSE::settings() const
 {
-  return {PluginSetting("enderal_downloads", "allow Enderal and Enderal SE downloads",
-                        QVariant(false))};
+return {}; //Must return something, otherwise linker erros smh
 }
 
 void GameSkyrimSE::initializeProfile(const QDir& path, ProfileSettings settings) const
@@ -268,9 +267,6 @@ QString GameSkyrimSE::gameShortName() const
 QStringList GameSkyrimSE::validShortNames() const
 {
   QStringList shortNames{"Skyrim"};
-  if (m_Organizer->pluginSetting(name(), "enderal_downloads").toBool()) {
-    shortNames.append({"Enderal", "EnderalSE"});
-  }
   return shortNames;
 }
 

--- a/src/gameskyrimse.cpp
+++ b/src/gameskyrimse.cpp
@@ -266,7 +266,7 @@ QString GameSkyrimSE::gameShortName() const
 
 QStringList GameSkyrimSE::validShortNames() const
 {
-  QStringList shortNames{"Skyrim"};
+  QStringList shortNames{"Skyrim", "Enderal", "EnderalSE"};
   return shortNames;
 }
 

--- a/src/skyrimsemoddatachecker.h
+++ b/src/skyrimsemoddatachecker.h
@@ -12,13 +12,14 @@ protected:
   virtual const FileNameSet& possibleFolderNames() const override
   {
     static FileNameSet result{
-        "fonts",     "interface",      "menus",         "meshes",
-        "music",     "scripts",        "shaders",       "sound",
-        "strings",   "textures",       "trees",         "video",
-        "facegen",   "materials",      "skse",          "distantlod",
-        "asi",       "Tools",          "MCM",           "distantland",
-        "mits",      "dllplugins",     "CalienteTools", "NetScriptFramework",
-        "shadersfx", "Nemesis_Engine", "Platform",      "grass"};
+        "fonts",         "interface",      "menus",         "meshes",
+        "music",         "scripts",        "shaders",       "sound",
+        "strings",       "textures",       "trees",         "video",
+        "facegen",       "materials",      "skse",          "distantlod",
+        "asi",           "Tools",          "MCM",           "distantland",
+        "mits",          "dllplugins",     "CalienteTools", "NetScriptFramework",
+        "shadersfx",     "Nemesis_Engine", "Platform",      "grass",
+        "ParticleLights"};
     return result;
   }
   virtual const FileNameSet& possibleFileExtensions() const override


### PR DESCRIPTION
# Authors
- @Ungeziefi
- @Senjay-id 

# Motivations
- There isn't much point to the Enderal settings when all it's used for is short-names
- The `ParticleLights` is a valid mod data directory